### PR TITLE
ergo-nix(node): dump to 3.3.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 # The following pins to a specific version of ergo-nix
-ERGO_NIX_SOURCE=https://github.com/ergoplatform/ergo-nix/archive/821e29679f1338978c4962276b84015a0de7cbfd.tar.gz
+ERGO_NIX_SOURCE=https://github.com/ergoplatform/ergo-nix/archive/7bca94f25777964043cdd3d6eb76e588befbeb98.tar.gz

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 # The following pins to a specific version of ergo-nix
-ERGO_NIX_SOURCE=https://github.com/ergoplatform/ergo-nix/archive/c9c543b887c6ccffd6f26cdbe38f3bc0782f8651.tar.gz
+ERGO_NIX_SOURCE=https://github.com/ergoplatform/ergo-nix/archive/821e29679f1338978c4962276b84015a0de7cbfd.tar.gz


### PR DESCRIPTION
Bumping ergo-nix for support of 3.3.7.

To upgrade, run the following in your `ergo-bootstrap` directory.

```
docker-compose build --no-cache ergo-node ergo-explorer-api ergo-explorer-backend-chain-grabber ergo-explorer-utx-tracker ergo-explorer-utx-broadcaster
docker-compose up -d --force-recreate --no-deps ergo-node ergo-explorer-api ergo-explorer-backend-chain-grabber ergo-explorer-utx-tracker ergo-explorer-utx-broadcaster
```